### PR TITLE
fix cache in a couple of places

### DIFF
--- a/src/main/java/me/contaria/seedqueue/compat/ModCompat.java
+++ b/src/main/java/me/contaria/seedqueue/compat/ModCompat.java
@@ -46,13 +46,24 @@ public class ModCompat {
         }
     }
 
-    public static void standardsettings$cacheAndReset() {
+    public static void standardsettings$cache() {
+        if (HAS_STANDARDSETTINGS) {
+            StandardSettingsCompat.createCache();
+        }
+    }
+
+    public static void standardsettings$reset() {
         if (HAS_STANDARDSETTINGS) {
             StandardSettingsCompat.resetPendingActions();
-            StandardSettingsCompat.createCache();
             if (StandardSettings.isEnabled()) {
-                StandardSettings.reset();
+                StandardSettingsCompat.reset();
             }
+        }
+    }
+
+    public static void standardsettings$loadCache() {
+        if (HAS_STANDARDSETTINGS) {
+            StandardSettingsCompat.loadCache();
         }
     }
 

--- a/src/main/java/me/contaria/seedqueue/compat/ModCompat.java
+++ b/src/main/java/me/contaria/seedqueue/compat/ModCompat.java
@@ -67,12 +67,6 @@ public class ModCompat {
         }
     }
 
-    public static void standardsettings$onWorldJoin() {
-        if (HAS_STANDARDSETTINGS) {
-            StandardSettingsCompat.onWorldJoin();
-        }
-    }
-
     public static boolean worldpreview$inPreview() {
         if (HAS_WORLDPREVIEW) {
             return WorldPreviewCompat.inPreview();

--- a/src/main/java/me/contaria/seedqueue/compat/StandardSettingsCompat.java
+++ b/src/main/java/me/contaria/seedqueue/compat/StandardSettingsCompat.java
@@ -16,10 +16,6 @@ class StandardSettingsCompat {
         StandardSettings.resetPendingActions();
     }
 
-    static void onWorldJoin() {
-        StandardSettings.onWorldJoin();
-    }
-
     static void loadCache() {
         StandardSettings.loadCache(StandardSettings.lastWorld);
     }

--- a/src/main/java/me/contaria/seedqueue/compat/StandardSettingsCompat.java
+++ b/src/main/java/me/contaria/seedqueue/compat/StandardSettingsCompat.java
@@ -19,4 +19,8 @@ class StandardSettingsCompat {
     static void onWorldJoin() {
         StandardSettings.onWorldJoin();
     }
+
+    static void loadCache() {
+        StandardSettings.loadCache(StandardSettings.lastWorld);
+    }
 }

--- a/src/main/java/me/contaria/seedqueue/gui/wall/SeedQueueWallScreen.java
+++ b/src/main/java/me/contaria/seedqueue/gui/wall/SeedQueueWallScreen.java
@@ -453,7 +453,6 @@ public class SeedQueueWallScreen extends Screen {
         }
 
         if (keyCode == GLFW.GLFW_KEY_ESCAPE && Screen.hasShiftDown()) {
-            ModCompat.standardsettings$onWorldJoin();
             ModCompat.standardsettings$loadCache();
             Atum.stopRunning();
             this.client.openScreen(new TitleScreen());

--- a/src/main/java/me/contaria/seedqueue/gui/wall/SeedQueueWallScreen.java
+++ b/src/main/java/me/contaria/seedqueue/gui/wall/SeedQueueWallScreen.java
@@ -454,6 +454,7 @@ public class SeedQueueWallScreen extends Screen {
 
         if (keyCode == GLFW.GLFW_KEY_ESCAPE && Screen.hasShiftDown()) {
             ModCompat.standardsettings$onWorldJoin();
+            ModCompat.standardsettings$loadCache();
             Atum.stopRunning();
             this.client.openScreen(new TitleScreen());
             return true;

--- a/src/main/java/me/contaria/seedqueue/mixin/client/patch/GLDebugMixin.java
+++ b/src/main/java/me/contaria/seedqueue/mixin/client/patch/GLDebugMixin.java
@@ -21,7 +21,8 @@ public abstract class GLDebugMixin {
             at = @At(
                     value = "INVOKE",
                     target = "Lorg/apache/logging/log4j/Logger;info(Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)V"
-            )
+            ),
+            remap = false
     )
     private static void suppressOpenGLDebugMessageSpam(Logger logger, String message, Object id, Object source, Object type, Object severity, Object msg, Operation<Void> original) {
         if (Objects.equals(id, 1281)) {

--- a/src/main/java/me/contaria/seedqueue/mixin/compat/atum/AtumMixin.java
+++ b/src/main/java/me/contaria/seedqueue/mixin/compat/atum/AtumMixin.java
@@ -26,6 +26,7 @@ public abstract class AtumMixin {
             )
     )
     private static Screen openSeedQueueWallScreen(Screen screen) {
+        ModCompat.standardsettings$cache();
         if (SeedQueue.isActive() && SeedQueue.config.shouldUseWall()) {
             if (SeedQueue.config.bypassWall) {
                 Optional<SeedQueueEntry> nextSeedQueueEntry = SeedQueue.getEntryMatching(entry -> entry.isReady() && entry.isLocked());
@@ -34,7 +35,7 @@ public abstract class AtumMixin {
                     return screen;
                 }
             }
-            ModCompat.standardsettings$cacheAndReset();
+            ModCompat.standardsettings$reset();
             ModCompat.stateoutput$setWallState();
             return new SeedQueueWallScreen(screen);
         }


### PR DESCRIPTION
changes:
- caches previous world when switching to next via bypass lock option
- restores the cache when leaving the queue from wall, as wall resets options when joining
  - semi-relevant for glitched, if quitting from wall screen, changing options in title screen will be reset upon rejoining. this shouldn't necessarily be encouraged, but i can't see any reason to not support it
- remap = false the new injector, closes #19

there's a good chance i missed something (and also working around mixinextras) so feel free to reimplement / fix however you like.


