### PR TITLE
Restore positions of main group previews

### DIFF
--- a/src/main/java/me/contaria/seedqueue/SeedQueueEntry.java
+++ b/src/main/java/me/contaria/seedqueue/SeedQueueEntry.java
@@ -45,6 +45,8 @@ public class SeedQueueEntry {
     private volatile boolean loaded;
     private volatile boolean discarded;
 
+    private volatile int lockPosition;
+
     public SeedQueueEntry(MinecraftServer server, LevelStorage.Session session, MinecraftClient.IntegratedResourceManager resourceManager, YggdrasilAuthenticationService yggdrasilAuthenticationService, MinecraftSessionService minecraftSessionService, GameProfileRepository gameProfileRepository, @Nullable UserCache userCache) {
         this.server = server;
         this.session = session;
@@ -53,6 +55,8 @@ public class SeedQueueEntry {
         this.minecraftSessionService = minecraftSessionService;
         this.gameProfileRepository = gameProfileRepository;
         this.userCache = userCache;
+
+        this.lockPosition = -1;
 
         ((SQMinecraftServer) server).seedQueue$setEntry(this);
     }
@@ -293,14 +297,23 @@ public class SeedQueueEntry {
     }
 
     /**
+     * @see SeedQueueEntry#lock
+     */
+    public int getLockPosition() {
+        return this.lockPosition;
+    }
+
+    /**
      * Locks this entry from being mass-reset on the Wall Screen.
      * Mass Resets include Reset All, Focus Reset, Reset Row, Reset Column.
      *
+     * @param lockPosition The position (index) of this entry in the wall screen's main group.
      * @return True if the entry was not locked before.
      */
-    public boolean lock() {
+    public boolean lock(int lockPosition) {
         if (!this.locked) {
             this.locked = true;
+            this.lockPosition = lockPosition;
             SeedQueue.ping();
             return true;
         }

--- a/src/main/java/me/contaria/seedqueue/SeedQueueEntry.java
+++ b/src/main/java/me/contaria/seedqueue/SeedQueueEntry.java
@@ -45,7 +45,11 @@ public class SeedQueueEntry {
     private volatile boolean loaded;
     private volatile boolean discarded;
 
-    public volatile int mainPosition;
+    /**
+     * Stores the position (index) of the queue entry in the wall screen's main group.
+     * A value of -1 indicates that this entry is not in the main group.
+     */
+    public int mainPosition = -1;
 
     public SeedQueueEntry(MinecraftServer server, LevelStorage.Session session, MinecraftClient.IntegratedResourceManager resourceManager, YggdrasilAuthenticationService yggdrasilAuthenticationService, MinecraftSessionService minecraftSessionService, GameProfileRepository gameProfileRepository, @Nullable UserCache userCache) {
         this.server = server;
@@ -55,8 +59,6 @@ public class SeedQueueEntry {
         this.minecraftSessionService = minecraftSessionService;
         this.gameProfileRepository = gameProfileRepository;
         this.userCache = userCache;
-
-        this.mainPosition = -1;
 
         ((SQMinecraftServer) server).seedQueue$setEntry(this);
     }

--- a/src/main/java/me/contaria/seedqueue/SeedQueueEntry.java
+++ b/src/main/java/me/contaria/seedqueue/SeedQueueEntry.java
@@ -45,7 +45,7 @@ public class SeedQueueEntry {
     private volatile boolean loaded;
     private volatile boolean discarded;
 
-    private volatile int lockPosition;
+    public volatile int mainPosition;
 
     public SeedQueueEntry(MinecraftServer server, LevelStorage.Session session, MinecraftClient.IntegratedResourceManager resourceManager, YggdrasilAuthenticationService yggdrasilAuthenticationService, MinecraftSessionService minecraftSessionService, GameProfileRepository gameProfileRepository, @Nullable UserCache userCache) {
         this.server = server;
@@ -56,7 +56,7 @@ public class SeedQueueEntry {
         this.gameProfileRepository = gameProfileRepository;
         this.userCache = userCache;
 
-        this.lockPosition = -1;
+        this.mainPosition = -1;
 
         ((SQMinecraftServer) server).seedQueue$setEntry(this);
     }
@@ -297,23 +297,14 @@ public class SeedQueueEntry {
     }
 
     /**
-     * @see SeedQueueEntry#lock
-     */
-    public int getLockPosition() {
-        return this.lockPosition;
-    }
-
-    /**
      * Locks this entry from being mass-reset on the Wall Screen.
      * Mass Resets include Reset All, Focus Reset, Reset Row, Reset Column.
      *
-     * @param lockPosition The position (index) of this entry in the wall screen's main group.
      * @return True if the entry was not locked before.
      */
-    public boolean lock(int lockPosition) {
+    public boolean lock() {
         if (!this.locked) {
             this.locked = true;
-            this.lockPosition = lockPosition;
             SeedQueue.ping();
             return true;
         }

--- a/src/main/java/me/contaria/seedqueue/gui/wall/SeedQueueWallScreen.java
+++ b/src/main/java/me/contaria/seedqueue/gui/wall/SeedQueueWallScreen.java
@@ -305,9 +305,7 @@ public class SeedQueueWallScreen extends Screen {
     }
 
     private void addLockedPreview(SeedQueuePreview preview) {
-        Objects.requireNonNull(preview);
-
-        this.lockedPreviews.add(preview);
+        Objects.requireNonNull(this.lockedPreviews).add(preview);
         preview.getSeedQueueEntry().mainPosition = -1;
     }
 

--- a/src/main/java/me/contaria/seedqueue/gui/wall/SeedQueueWallScreen.java
+++ b/src/main/java/me/contaria/seedqueue/gui/wall/SeedQueueWallScreen.java
@@ -299,9 +299,27 @@ public class SeedQueueWallScreen extends Screen {
     }
 
     private void updatePreviews() {
+        this.restoreLockedPreviews();
         this.updateLockedPreviews();
         this.updateMainPreviews();
         this.updatePreparingPreviews();
+    }
+
+    private void restoreLockedPreviews() {
+        List<SeedQueueEntry> entries = this.getAvailableSeedQueueEntries();
+        for (SeedQueueEntry entry : entries) {
+            int lockPosition = entry.getLockPosition();
+            if (lockPosition == -1) {
+                continue;
+            }
+
+            if (lockPosition >= this.mainPreviews.length) {
+                continue;
+            }
+
+            assert this.mainPreviews[lockPosition] == null;
+            this.mainPreviews[lockPosition] = new SeedQueuePreview(this, entry);
+        }
     }
 
     private void updateLockedPreviews() {
@@ -583,7 +601,16 @@ public class SeedQueueWallScreen extends Screen {
     }
 
     private void lockInstance(SeedQueuePreview instance) {
-        if (instance.hasPreviewRendered() && instance.getSeedQueueEntry().lock()) {
+        // TODO: Pass the index of the preview as an argument to lockInstance?
+        int lockPosition = -1;
+        for (int i = 0; i < this.mainPreviews.length; i++) {
+            if (this.mainPreviews[i] == instance) {
+                lockPosition = i;
+                break;
+            }
+        }
+
+        if (instance.hasPreviewRendered() && instance.getSeedQueueEntry().lock(lockPosition)) {
             if (SeedQueue.config.freezeLockedPreviews) {
                 // clearing WorldPreviewProperties frees the previews WorldRenderer, allowing resources to be cleared
                 // it also means the amount of WorldRenderers does not exceed Rows * Columns + Background Previews

--- a/src/main/java/me/contaria/seedqueue/gui/wall/SeedQueueWallScreen.java
+++ b/src/main/java/me/contaria/seedqueue/gui/wall/SeedQueueWallScreen.java
@@ -315,10 +315,14 @@ public class SeedQueueWallScreen extends Screen {
             if (entry.mainPosition >= this.mainPreviews.length) {
                 continue;
             }
+    private void addLockedPreview(SeedQueuePreview preview) {
+        assert this.lockedPreviews != null;
 
             assert this.mainPreviews[entry.mainPosition] == null;
             this.mainPreviews[entry.mainPosition] = new SeedQueuePreview(this, entry);
         }
+        this.lockedPreviews.add(preview);
+        preview.getSeedQueueEntry().mainPosition = -1;
     }
 
     private void updateLockedPreviews() {
@@ -327,13 +331,13 @@ public class SeedQueueWallScreen extends Screen {
         }
         for (SeedQueueEntry entry : this.getAvailableSeedQueueEntries()) {
             if (entry.isLocked()) {
-                this.lockedPreviews.add(new SeedQueuePreview(this, entry));
+                this.addLockedPreview(new SeedQueuePreview(this, entry));
             }
         }
         for (int i = 0; i < this.mainPreviews.length; i++) {
             SeedQueuePreview instance = this.mainPreviews[i];
             if (instance != null && instance.getSeedQueueEntry().isLocked()) {
-                this.lockedPreviews.add(instance);
+                this.addLockedPreview(instance);
                 this.mainPreviews[i] = null;
                 if (!this.layout.replaceLockedInstances) {
                     this.blockedMainPositions.add(i);
@@ -342,7 +346,7 @@ public class SeedQueueWallScreen extends Screen {
         }
         for (SeedQueuePreview instance : this.preparingPreviews) {
             if (instance.getSeedQueueEntry().isLocked()) {
-                this.lockedPreviews.add(instance);
+                this.addLockedPreview(instance);
             }
         }
         this.preparingPreviews.removeAll(this.lockedPreviews);

--- a/src/main/java/me/contaria/seedqueue/gui/wall/SeedQueueWallScreen.java
+++ b/src/main/java/me/contaria/seedqueue/gui/wall/SeedQueueWallScreen.java
@@ -299,26 +299,25 @@ public class SeedQueueWallScreen extends Screen {
     }
 
     private void updatePreviews() {
-        this.restoreLockedPreviews();
+        this.restoreMainPreviews();
         this.updateLockedPreviews();
         this.updateMainPreviews();
         this.updatePreparingPreviews();
     }
 
-    private void restoreLockedPreviews() {
+    private void restoreMainPreviews() {
         List<SeedQueueEntry> entries = this.getAvailableSeedQueueEntries();
         for (SeedQueueEntry entry : entries) {
-            int lockPosition = entry.getLockPosition();
-            if (lockPosition == -1) {
+            if (entry.mainPosition == -1) {
                 continue;
             }
 
-            if (lockPosition >= this.mainPreviews.length) {
+            if (entry.mainPosition >= this.mainPreviews.length) {
                 continue;
             }
 
-            assert this.mainPreviews[lockPosition] == null;
-            this.mainPreviews[lockPosition] = new SeedQueuePreview(this, entry);
+            assert this.mainPreviews[entry.mainPosition] == null;
+            this.mainPreviews[entry.mainPosition] = new SeedQueuePreview(this, entry);
         }
     }
 
@@ -357,6 +356,7 @@ public class SeedQueueWallScreen extends Screen {
             }
             if (this.mainPreviews[i] == null && !this.blockedMainPositions.contains(i)) {
                 this.mainPreviews[i] = this.preparingPreviews.remove(0);
+                this.mainPreviews[i].getSeedQueueEntry().mainPosition = i;
             }
         }
     }
@@ -601,16 +601,7 @@ public class SeedQueueWallScreen extends Screen {
     }
 
     private void lockInstance(SeedQueuePreview instance) {
-        // TODO: Pass the index of the preview as an argument to lockInstance?
-        int lockPosition = -1;
-        for (int i = 0; i < this.mainPreviews.length; i++) {
-            if (this.mainPreviews[i] == instance) {
-                lockPosition = i;
-                break;
-            }
-        }
-
-        if (instance.hasPreviewRendered() && instance.getSeedQueueEntry().lock(lockPosition)) {
+        if (instance.hasPreviewRendered() && instance.getSeedQueueEntry().lock()) {
             if (SeedQueue.config.freezeLockedPreviews) {
                 // clearing WorldPreviewProperties frees the previews WorldRenderer, allowing resources to be cleared
                 // it also means the amount of WorldRenderers does not exceed Rows * Columns + Background Previews

--- a/src/main/java/me/contaria/seedqueue/gui/wall/SeedQueueWallScreen.java
+++ b/src/main/java/me/contaria/seedqueue/gui/wall/SeedQueueWallScreen.java
@@ -339,20 +339,24 @@ public class SeedQueueWallScreen extends Screen {
     }
 
     private void updateMainPreviews() {
-        for (SeedQueueEntry entry : this.getAvailableSeedQueueEntries()) {
-            if (entry.mainPosition == -1) {
+        for (int i = this.preparingPreviews.size() - 1; i >= 0; i--) {
+            SeedQueuePreview preview = this.preparingPreviews.get(i);
+            int position = preview.getSeedQueueEntry().mainPosition;
+
+            if (position == -1) {
                 continue;
             }
 
-            if (entry.mainPosition >= this.mainPreviews.length) {
-                entry.mainPosition = -1;
+            if (position >= this.mainPreviews.length) {
+                preview.getSeedQueueEntry().mainPosition = -1;
                 continue;
             }
 
-            if (this.mainPreviews[entry.mainPosition] != null) {
-                SeedQueue.LOGGER.warn("Main preview {} already populated", entry.mainPosition);
+            if (this.mainPreviews[position] != null) {
+                SeedQueue.LOGGER.warn("Main preview {} already populated", position);
             } else {
-                this.mainPreviews[entry.mainPosition] = new SeedQueuePreview(this, entry);
+                this.mainPreviews[position] = preview;
+                this.preparingPreviews.remove(i);
             }
         }
 
@@ -379,10 +383,6 @@ public class SeedQueueWallScreen extends Screen {
         if (this.preparingPreviews.size() < capacity) {
             int budget = Math.max(1, urgent);
             for (SeedQueueEntry entry : this.getAvailableSeedQueueEntries()) {
-                if (entry.mainPosition >= 0 && entry.mainPosition < this.mainPreviews.length) {
-                    continue;
-                }
-
                 this.preparingPreviews.add(new SeedQueuePreview(this, entry));
                 if (--budget <= 0) {
                     break;


### PR DESCRIPTION
Previously, locked previews would sometimes change location when `SeedQueueWallScreen` was reinitialized and all of the previews were updated again. This PR makes locked previews in the main group stay in the same position even after `SeedQueueWallScreen` is reinitialized.

https://github.com/user-attachments/assets/91ee75ff-7cfd-4284-ba6e-fe36d1dd5976

Closes #7