### PR TITLE
Clear queue when Atum button is shift clicked

### DIFF
--- a/src/main/java/me/contaria/seedqueue/mixin/compat/atum/OptionsScreenMixin.java
+++ b/src/main/java/me/contaria/seedqueue/mixin/compat/atum/OptionsScreenMixin.java
@@ -1,0 +1,72 @@
+package me.contaria.seedqueue.mixin.compat.atum;
+
+import com.bawnorton.mixinsquared.TargetHandler;
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import me.contaria.seedqueue.SeedQueue;
+import net.minecraft.client.gui.screen.Screen;
+import net.minecraft.client.gui.screen.options.OptionsScreen;
+import net.minecraft.client.gui.widget.ButtonWidget;
+import net.minecraft.text.Text;
+import net.minecraft.text.TranslatableText;
+import org.spongepowered.asm.mixin.Dynamic;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(value = OptionsScreen.class, priority = 1500)
+public abstract class OptionsScreenMixin extends Screen {
+    @Unique
+    private ButtonWidget atumButton;
+
+    protected OptionsScreenMixin(Text title) {
+        super(title);
+    }
+
+    @Unique
+    private boolean shouldClearQueue() {
+        return Screen.hasShiftDown() && SeedQueue.isActive();
+    }
+
+    @Dynamic
+    @TargetHandler(
+            mixin = "me.voidxwalker.autoreset.mixin.gui.OptionsScreenMixin",
+            name = "addStopResetsButton"
+    )
+    @WrapOperation(
+            method = "@MixinSquared:Handler",
+            at = @At(
+                    value = "NEW",
+                    target = "(IIIILnet/minecraft/text/Text;Lnet/minecraft/client/gui/widget/ButtonWidget$PressAction;)Lnet/minecraft/client/gui/widget/ButtonWidget;"
+            )
+    )
+    private ButtonWidget stopQueueWhenShiftClicked(int x, int y, int width, int height, Text text, ButtonWidget.PressAction action, Operation<ButtonWidget> original) {
+        this.atumButton = new ButtonWidget(x, y, width, height, text, button -> {
+            if (shouldClearQueue()) {
+                SeedQueue.stop();
+            } else {
+                action.onPress(button);
+            }
+        });
+
+        return this.atumButton;
+    }
+
+    @Inject(
+        method = "render(Lnet/minecraft/client/util/math/MatrixStack;IIF)V",
+        at = @At("HEAD")
+    )
+    private void setAtumButtonText(CallbackInfo ci) {
+        if (atumButton == null) {
+            return;
+        }
+
+        if (shouldClearQueue()) {
+            atumButton.setMessage(new TranslatableText("seedqueue.menu.clearQueue"));
+        } else {
+            atumButton.setMessage(new TranslatableText("atum.menu.stop_resets"));
+        }
+    }
+}

--- a/src/main/java/me/contaria/seedqueue/mixin/compat/atum/OptionsScreenMixin.java
+++ b/src/main/java/me/contaria/seedqueue/mixin/compat/atum/OptionsScreenMixin.java
@@ -17,13 +17,9 @@ import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(value = OptionsScreen.class, priority = 1500)
-public abstract class OptionsScreenMixin extends Screen {
+public abstract class OptionsScreenMixin {
     @Unique
     private ButtonWidget atumButton;
-
-    protected OptionsScreenMixin(Text title) {
-        super(title);
-    }
 
     @Dynamic
     @TargetHandler(

--- a/src/main/java/me/contaria/seedqueue/mixin/compat/atum/OptionsScreenMixin.java
+++ b/src/main/java/me/contaria/seedqueue/mixin/compat/atum/OptionsScreenMixin.java
@@ -25,11 +25,6 @@ public abstract class OptionsScreenMixin extends Screen {
         super(title);
     }
 
-    @Unique
-    private boolean shouldClearQueue() {
-        return Screen.hasShiftDown() && SeedQueue.isActive();
-    }
-
     @Dynamic
     @TargetHandler(
             mixin = "me.voidxwalker.autoreset.mixin.gui.OptionsScreenMixin",
@@ -43,15 +38,13 @@ public abstract class OptionsScreenMixin extends Screen {
             )
     )
     private ButtonWidget stopQueueWhenShiftClicked(int x, int y, int width, int height, Text text, ButtonWidget.PressAction action, Operation<ButtonWidget> original) {
-        this.atumButton = new ButtonWidget(x, y, width, height, text, button -> {
+        return this.atumButton = original.call(x, y, width, height, text, (ButtonWidget.PressAction)button -> {
             if (shouldClearQueue()) {
                 SeedQueue.stop();
             } else {
                 action.onPress(button);
             }
         });
-
-        return this.atumButton;
     }
 
     @Inject(
@@ -59,7 +52,7 @@ public abstract class OptionsScreenMixin extends Screen {
         at = @At("HEAD")
     )
     private void setAtumButtonText(CallbackInfo ci) {
-        if (atumButton == null) {
+        if (this.atumButton == null) {
             return;
         }
 
@@ -68,5 +61,10 @@ public abstract class OptionsScreenMixin extends Screen {
         } else {
             atumButton.setMessage(new TranslatableText("atum.menu.stop_resets"));
         }
+    }
+
+    @Unique
+    private boolean shouldClearQueue() {
+        return Screen.hasShiftDown() && SeedQueue.isActive();
     }
 }

--- a/src/main/java/me/contaria/seedqueue/mixin/compat/atum/OptionsScreenMixin.java
+++ b/src/main/java/me/contaria/seedqueue/mixin/compat/atum/OptionsScreenMixin.java
@@ -39,7 +39,7 @@ public abstract class OptionsScreenMixin extends Screen {
     )
     private ButtonWidget stopQueueWhenShiftClicked(int x, int y, int width, int height, Text text, ButtonWidget.PressAction action, Operation<ButtonWidget> original) {
         return this.atumButton = original.call(x, y, width, height, text, (ButtonWidget.PressAction)button -> {
-            if (shouldClearQueue()) {
+            if (this.shouldClearQueue()) {
                 SeedQueue.stop();
             } else {
                 action.onPress(button);
@@ -56,10 +56,10 @@ public abstract class OptionsScreenMixin extends Screen {
             return;
         }
 
-        if (shouldClearQueue() && this.atumButton.isHovered()) {
-            atumButton.setMessage(new TranslatableText("seedqueue.menu.clearQueue"));
+        if (this.shouldClearQueue() && this.atumButton.isHovered()) {
+            this.atumButton.setMessage(new TranslatableText("seedqueue.menu.clearQueue"));
         } else {
-            atumButton.setMessage(new TranslatableText("atum.menu.stop_resets"));
+            this.atumButton.setMessage(new TranslatableText("atum.menu.stop_resets"));
         }
     }
 

--- a/src/main/java/me/contaria/seedqueue/mixin/compat/atum/OptionsScreenMixin.java
+++ b/src/main/java/me/contaria/seedqueue/mixin/compat/atum/OptionsScreenMixin.java
@@ -56,7 +56,7 @@ public abstract class OptionsScreenMixin extends Screen {
             return;
         }
 
-        if (shouldClearQueue()) {
+        if (shouldClearQueue() && this.atumButton.isHovered()) {
             atumButton.setMessage(new TranslatableText("seedqueue.menu.clearQueue"));
         } else {
             atumButton.setMessage(new TranslatableText("atum.menu.stop_resets"));

--- a/src/main/resources/assets/seedqueue/lang/en_us.json
+++ b/src/main/resources/assets/seedqueue/lang/en_us.json
@@ -1,6 +1,8 @@
 {
   "seedqueue.menu.clearing": "Clearing SeedQueue...",
 
+  "seedqueue.menu.clearQueue": "Clear Queue",
+
   "seedqueue.menu.crash.title": "SeedQueue crashed!",
   "seedqueue.menu.crash.description": "Crashed with %s, check the log for more information.",
 

--- a/src/main/resources/seedqueue.mixins.json
+++ b/src/main/resources/seedqueue.mixins.json
@@ -28,6 +28,7 @@
     "compat.atum.AtumMixin",
     "compat.atum.CreateWorldScreenMixin",
     "compat.atum.KeyboardMixin",
+    "compat.atum.OptionsScreenMixin",
     "compat.sodium.ChunkBuilder$WorkerRunnableMixin",
     "compat.sodium.ChunkBuilder$WorkerRunnableMixin2",
     "compat.sodium.ChunkBuilderMixin",


### PR DESCRIPTION
The text of Atum's `Stop Resets & Quit` button changes to `Clear Queue` when shift is held down. Pressing the button will stop SeedQueue.

The button will not change when SeedQueue is inactive.

https://github.com/user-attachments/assets/e2c27db4-9e1c-4588-bc7d-51e72d226a66

Closes #11

I force-pushed the main branch and GitHub will not allow the previous PR to be reopened, even after restoring it. Sorry :sweat_smile: 