### PR TITLE
Fix restoration of previews to main group

### DIFF
--- a/src/main/java/me/contaria/seedqueue/gui/wall/SeedQueueWallScreen.java
+++ b/src/main/java/me/contaria/seedqueue/gui/wall/SeedQueueWallScreen.java
@@ -342,7 +342,7 @@ public class SeedQueueWallScreen extends Screen {
             int position = preview.getSeedQueueEntry().mainPosition;
 
             if (position == -1) {
-                continue;
+                break;
             }
 
             if (position >= this.mainPreviews.length) {
@@ -380,6 +380,12 @@ public class SeedQueueWallScreen extends Screen {
         int capacity = SeedQueue.config.backgroundPreviews + urgent;
         if (this.preparingPreviews.size() < capacity) {
             int budget = Math.max(1, urgent);
+
+            // see SeedQueueWallScreen#updateMainPreviews
+            // Previews which have previously been in the main group will have a position assigned
+            // to them. They must be sorted to appear first in SeedQueueWallScreen#preparingPreviews
+            // so that they can be restored to the correct location before any other previews take
+            // their place.
             List<SeedQueueEntry> entries = this.getAvailableSeedQueueEntries();
             entries.sort(Comparator.comparing(entry -> entry.mainPosition, Comparator.reverseOrder()));
 

--- a/src/main/java/me/contaria/seedqueue/gui/wall/SeedQueueWallScreen.java
+++ b/src/main/java/me/contaria/seedqueue/gui/wall/SeedQueueWallScreen.java
@@ -348,7 +348,10 @@ public class SeedQueueWallScreen extends Screen {
         int capacity = SeedQueue.config.backgroundPreviews + urgent;
         if (this.preparingPreviews.size() < capacity) {
             int budget = Math.max(1, urgent);
-            for (SeedQueueEntry entry : this.getAvailableSeedQueueEntries()) {
+            List<SeedQueueEntry> entries = this.getAvailableSeedQueueEntries();
+            entries.sort(Comparator.comparing(entry -> entry.mainPosition, Comparator.reverseOrder()));
+
+            for (SeedQueueEntry entry : entries) {
                 this.preparingPreviews.add(new SeedQueuePreview(this, entry));
                 if (--budget <= 0) {
                     break;


### PR DESCRIPTION
Depending on the user's wall configuration and the value of their Background Previews setting, it is possible for SeedQueueEntries with no `mainPosition` to be turned into previews before those which do have `mainPosition` set. This causes the restoration of previews to their previous spots in the main group to fail.

Reverting the change in [3695d0f](https://github.com/KingContaria/seedqueue/pull/34/commits/3695d0fb8245156c66692a36f03f10d494625a38) and sorting SeedQueueEntries by their `mainPosition` value in `updatePreparingPreviews` fixes the problem and ensures that previews will always be restored to the correct position in the main group.