### PR TITLE
Add "village wall" functionality

### DIFF
--- a/src/main/java/me/contaria/seedqueue/SeedQueueEntry.java
+++ b/src/main/java/me/contaria/seedqueue/SeedQueueEntry.java
@@ -51,6 +51,11 @@ public class SeedQueueEntry {
      */
     public int mainPosition = -1;
 
+    /**
+     * Stores the time in ms when the entry last started generating a new world.
+     */
+    public long lastGeneratingTime;
+    
     public SeedQueueEntry(MinecraftServer server, LevelStorage.Session session, MinecraftClient.IntegratedResourceManager resourceManager, YggdrasilAuthenticationService yggdrasilAuthenticationService, MinecraftSessionService minecraftSessionService, GameProfileRepository gameProfileRepository, @Nullable UserCache userCache) {
         this.server = server;
         this.session = session;

--- a/src/main/java/me/contaria/seedqueue/SeedQueueThread.java
+++ b/src/main/java/me/contaria/seedqueue/SeedQueueThread.java
@@ -93,6 +93,9 @@ public class SeedQueueThread extends Thread {
             }
         }
         for (SeedQueueEntry entry : entries) {
+            if(/*option check for village wall && */ entry.getWorldGenerationProgressTracker() != null && System.currentTimeMillis() - entry.lastGeneratingTime > 160L /*(should be set with options)*/)
+        		entry.getWorldGenerationProgressTracker().stop();
+            
             if (entry.tryToUnpause()) {
                 return true;
             }

--- a/src/main/java/me/contaria/seedqueue/gui/wall/SeedQueuePreview.java
+++ b/src/main/java/me/contaria/seedqueue/gui/wall/SeedQueuePreview.java
@@ -77,6 +77,8 @@ public class SeedQueuePreview extends LevelLoadingScreen {
                 SeedQueue.config.simulatedWindowSize.height() / scale
         );
 
+        this.seedQueueEntry.lastGeneratingTime = System.currentTimeMillis();
+        
         if (Boolean.TRUE.equals(SpeedrunConfigAPI.getConfigValue("standardsettings", "autoF3Esc"))) {
             Text backToGame = new TranslatableText("menu.returnToGame");
             for (Element e : this.children()) {


### PR DESCRIPTION
example of this in action: https://youtu.be/6LKsm9Z0gTU

allows you to spot village pauses after they've happened by freezing the chunkmap after a certain time

Any help is appreciated!! I don't know much about the seedqueue code base but I got this to work. But there of course needs to a setting to activate this mode and you also need to be able to configure after how long time the chunkmap should freeze