### PR TITLE
Restore main previews from front of list

### DIFF
--- a/src/main/java/me/contaria/seedqueue/gui/wall/SeedQueueWallScreen.java
+++ b/src/main/java/me/contaria/seedqueue/gui/wall/SeedQueueWallScreen.java
@@ -337,8 +337,9 @@ public class SeedQueueWallScreen extends Screen {
     }
 
     private void updateMainPreviews() {
-        for (int i = this.preparingPreviews.size() - 1; i >= 0; i--) {
-            SeedQueuePreview preview = this.preparingPreviews.get(i);
+        int preparingCount = this.preparingPreviews.size();
+        for (int i = 0; i < preparingCount; i++) {
+            SeedQueuePreview preview = this.preparingPreviews.get(0);
             int position = preview.getSeedQueueEntry().mainPosition;
 
             if (position == -1) {
@@ -354,7 +355,7 @@ public class SeedQueueWallScreen extends Screen {
                 SeedQueue.LOGGER.warn("Main preview {} already populated", position);
             } else {
                 this.mainPreviews[position] = preview;
-                this.preparingPreviews.remove(i);
+                this.preparingPreviews.remove(0);
             }
         }
 


### PR DESCRIPTION
Iterating from the back of `SeedQueueWallScreen#preparingPreviews` and breaking upon hitting a `mainPosition` of -1 causes the restoration of main previews to fail if there is not a full set of previews to place in the main group.

Hopefully this is the last bug fix for this feature :sweat_smile: 