### PR TITLE
Fix: Reset cooldown now applies to preparing seeds that move to main grid

### DIFF
--- a/src/main/java/me/contaria/seedqueue/gui/wall/SeedQueuePreview.java
+++ b/src/main/java/me/contaria/seedqueue/gui/wall/SeedQueuePreview.java
@@ -202,6 +202,10 @@ public class SeedQueuePreview extends LevelLoadingScreen {
         return System.currentTimeMillis() - this.cooldownStart >= SeedQueue.config.resetCooldown;
     }
 
+    public void resetCooldown() {
+        this.cooldownStart = System.currentTimeMillis();
+    }
+
     public boolean canReset(boolean ignoreLock, boolean ignoreResetCooldown) {
         return this.hasPreviewRendered() && (!this.seedQueueEntry.isLocked() || ignoreLock) && (this.isCooldownReady() || ignoreResetCooldown) && SeedQueue.selectedEntry != this.seedQueueEntry;
     }

--- a/src/main/java/me/contaria/seedqueue/gui/wall/SeedQueuePreview.java
+++ b/src/main/java/me/contaria/seedqueue/gui/wall/SeedQueuePreview.java
@@ -203,7 +203,7 @@ public class SeedQueuePreview extends LevelLoadingScreen {
     }
 
     public void resetCooldown() {
-        this.cooldownStart = System.currentTimeMillis();
+        this.cooldownStart = Long.MAX_VALUE;
     }
 
     public boolean canReset(boolean ignoreLock, boolean ignoreResetCooldown) {

--- a/src/main/java/me/contaria/seedqueue/gui/wall/SeedQueueWallScreen.java
+++ b/src/main/java/me/contaria/seedqueue/gui/wall/SeedQueueWallScreen.java
@@ -365,7 +365,9 @@ public class SeedQueueWallScreen extends Screen {
                 break;
             }
             if (this.mainPreviews[i] == null && !this.blockedMainPositions.contains(i)) {
+                SeedQueuePreview preview = this.preparingPreviews.get(0);
                 this.mainPreviews[i] = this.preparingPreviews.remove(0);
+                preview.resetCooldown();
 
                 if (this.mainPreviews[i].getSeedQueueEntry().mainPosition != -1) {
                     SeedQueue.LOGGER.warn("Main preview {} already assigned a position", i);

--- a/src/main/java/me/contaria/seedqueue/gui/wall/SeedQueueWallScreen.java
+++ b/src/main/java/me/contaria/seedqueue/gui/wall/SeedQueueWallScreen.java
@@ -365,9 +365,8 @@ public class SeedQueueWallScreen extends Screen {
                 break;
             }
             if (this.mainPreviews[i] == null && !this.blockedMainPositions.contains(i)) {
-                SeedQueuePreview preview = this.preparingPreviews.get(0);
                 this.mainPreviews[i] = this.preparingPreviews.remove(0);
-                preview.resetCooldown();
+                this.mainPreviews[i].resetCooldown();
 
                 if (this.mainPreviews[i].getSeedQueueEntry().mainPosition != -1) {
                     SeedQueue.LOGGER.warn("Main preview {} already assigned a position", i);


### PR DESCRIPTION
Fixes #13 as reset cooldown is now also applied to preparing seeds that move to main grid.