### PR TITLE
fix: Resume On Queue Full bug with early locking.

### DIFF
--- a/src/main/java/me/contaria/seedqueue/SeedQueueThread.java
+++ b/src/main/java/me/contaria/seedqueue/SeedQueueThread.java
@@ -36,9 +36,10 @@ public class SeedQueueThread extends Thread {
                     this.pauseSeedQueueEntry();
                     continue;
                 }
-                if (!SeedQueue.shouldGenerate() || SeedQueue.shouldResumeAfterQueueFull()) {
+                boolean shouldResumeAfterQueueFull = SeedQueue.shouldResumeAfterQueueFull();
+                if (!SeedQueue.shouldGenerate() || shouldResumeAfterQueueFull) {
                     boolean shouldResumeGenerating = SeedQueue.shouldResumeGenerating();
-                    if (!shouldResumeGenerating && !SeedQueue.noLockedRemaining()) {
+                    if (!shouldResumeGenerating && !SeedQueue.noLockedRemaining() && shouldResumeAfterQueueFull) {
                         this.pauseSeedQueueEntry();
                         continue;
                     }


### PR DESCRIPTION
As discussed in the discord, there was a bug in Resume On Queue Full where it paused the last few generating previews before it reached the max world generation percentage if another preview was locked before the queue is filled. 

This PR fixes that issue.