### PR TITLE
Fix: Round when doing layout mul to prevent double precision errors.

### DIFF
--- a/src/main/java/me/contaria/seedqueue/customization/Layout.java
+++ b/src/main/java/me/contaria/seedqueue/customization/Layout.java
@@ -11,6 +11,7 @@ import org.jetbrains.annotations.Nullable;
 
 import java.io.InputStreamReader;
 import java.io.Reader;
+import java.math.BigDecimal;
 import java.nio.charset.StandardCharsets;
 
 public class Layout {
@@ -55,11 +56,8 @@ public class Layout {
     private static int getAsInt(JsonObject jsonObject, String name, int windowSize) {
         JsonPrimitive jsonPrimitive = jsonObject.getAsJsonPrimitive(name);
         if (jsonPrimitive.isNumber() && jsonPrimitive.toString().contains(".")) {
-            // Double precision can lead to inaccurate multiplications here.
-            // BigDecimal would solve some cases (where the layout is perfectly divisible) but it is much
-            // simpler to just make the decision to round(), which both fixes perfect situations, and also
-            // may lead to more accurate layout representations in general.
-            return Math.round(windowSize * jsonPrimitive.getAsDouble());
+            // Using BigDecimal here fixes some potential floating point issues.
+            return BigDecimal.valueOf(windowSize).multiply(new BigDecimal(jsonPrimitive.toString())).intValue();
         }
         return jsonPrimitive.getAsInt();
     }

--- a/src/main/java/me/contaria/seedqueue/customization/Layout.java
+++ b/src/main/java/me/contaria/seedqueue/customization/Layout.java
@@ -57,7 +57,7 @@ public class Layout {
         JsonPrimitive jsonPrimitive = jsonObject.getAsJsonPrimitive(name);
         if (jsonPrimitive.isNumber() && jsonPrimitive.toString().contains(".")) {
             // Using BigDecimal here fixes some potential floating point issues.
-            return BigDecimal.valueOf(windowSize).multiply(new BigDecimal(jsonPrimitive.toString())).intValue();
+            return BigDecimal.valueOf(windowSize).multiply(jsonPrimitive.getAsBigDecimal()).intValue();
         }
         return jsonPrimitive.getAsInt();
     }

--- a/src/main/java/me/contaria/seedqueue/customization/Layout.java
+++ b/src/main/java/me/contaria/seedqueue/customization/Layout.java
@@ -55,7 +55,11 @@ public class Layout {
     private static int getAsInt(JsonObject jsonObject, String name, int windowSize) {
         JsonPrimitive jsonPrimitive = jsonObject.getAsJsonPrimitive(name);
         if (jsonPrimitive.isNumber() && jsonPrimitive.toString().contains(".")) {
-            return (int) (windowSize * jsonPrimitive.getAsDouble());
+            // Double precision can lead to inaccurate multiplications here.
+            // BigDecimal would solve some cases (where the layout is perfectly divisible) but it is much
+            // simpler to just make the decision to round(), which both fixes perfect situations, and also
+            // may lead to more accurate layout representations in general.
+            return Math.round(windowSize * jsonPrimitive.getAsDouble());
         }
         return jsonPrimitive.getAsInt();
     }


### PR DESCRIPTION
`BigDecimal` may be a better solution here (or perhaps another solution not yet thought of?)

Anyways, this should fix all cases of off-by-one regardless, it's just possible there are other issues this could introduce that I'm not thinking of right now.