### PR TITLE
Feature/custom text elements

### DIFF
--- a/src/main/java/me/contaria/seedqueue/customization/Layout.java
+++ b/src/main/java/me/contaria/seedqueue/customization/Layout.java
@@ -207,12 +207,14 @@ public class Layout {
         public final Pos pos;
         public final int color;
         public final float lineSpacing;
+        public final boolean shadow;
         public final Path path;
 
-        CustomTextObject(Pos pos, int color, float lineSpacing, Path path) {
+        CustomTextObject(Pos pos, int color, float lineSpacing, boolean shadow, Path path) {
             this.pos = pos;
             this.color = color;
             this.lineSpacing = lineSpacing;
+            this.shadow = shadow;
             this.path = path;
         }
 
@@ -229,6 +231,7 @@ public class Layout {
                     Pos.fromJson(jsonObject),
                     getColor(jsonObject),
                     jsonObject.has("lineSpacing") ? jsonObject.get("lineSpacing").getAsFloat() : 9.0f,
+                    jsonObject.has("shadow") && jsonObject.get("shadow").getAsBoolean(),
                     Paths.get(jsonObject.get("path").getAsString())
             );
         }

--- a/src/main/java/me/contaria/seedqueue/gui/wall/SeedQueueWallScreen.java
+++ b/src/main/java/me/contaria/seedqueue/gui/wall/SeedQueueWallScreen.java
@@ -22,8 +22,7 @@ import net.minecraft.client.gui.DrawableHelper;
 import net.minecraft.client.gui.hud.DebugHud;
 import net.minecraft.client.gui.screen.Screen;
 import net.minecraft.client.gui.screen.TitleScreen;
-import net.minecraft.client.render.BufferBuilderStorage;
-import net.minecraft.client.render.WorldRenderer;
+import net.minecraft.client.render.*;
 import net.minecraft.client.util.Window;
 import net.minecraft.client.util.math.MatrixStack;
 import net.minecraft.client.world.ClientWorld;
@@ -265,7 +264,11 @@ public class SeedQueueWallScreen extends Screen {
             List<StringRenderable> lines = Files.readAllLines(customTextObject.path).stream().map(StringRenderable::plain).collect(Collectors.toList());
             this.setViewport(customTextObject.pos);
             for (int i = 0; i < lines.size(); i++) {
-                this.client.textRenderer.draw(matrices, lines.get(i), 0, customTextObject.lineSpacing * i, customTextObject.color);
+                if (customTextObject.shadow) {
+                    this.client.textRenderer.drawWithShadow(matrices, lines.get(i), 0, customTextObject.lineSpacing * i, customTextObject.color);
+                } else {
+                    this.client.textRenderer.draw(matrices, lines.get(i), 0, customTextObject.lineSpacing * i, customTextObject.color);
+                }
             }
             this.resetViewport();
         } catch (IOException e) {

--- a/src/main/java/me/contaria/seedqueue/gui/wall/SeedQueueWallScreen.java
+++ b/src/main/java/me/contaria/seedqueue/gui/wall/SeedQueueWallScreen.java
@@ -1,6 +1,5 @@
 package me.contaria.seedqueue.gui.wall;
 
-import com.google.gson.*;
 import com.mojang.blaze3d.systems.RenderSystem;
 import me.contaria.seedqueue.SeedQueue;
 import me.contaria.seedqueue.SeedQueueEntry;
@@ -36,9 +35,6 @@ import org.apache.commons.lang3.ArrayUtils;
 import org.jetbrains.annotations.Nullable;
 import org.lwjgl.glfw.GLFW;
 
-import java.net.HttpURLConnection;
-import java.net.MalformedURLException;
-import java.net.URL;
 import java.nio.file.Files;
 import java.io.IOException;
 import java.nio.file.Path;
@@ -180,7 +176,6 @@ public class SeedQueueWallScreen extends Screen {
             this.drawCustomTextFromFile(matrices, path, 0 , 0, 0xffffff);
             path = Paths.get("C:\\Users\\Jude\\IdeaProjects\\seedqueue\\run\\options.txt");
             this.drawCustomTextFromFile(matrices, path, 40 , 70, 0x80117a);
-//            this.drawCustomTextFromURL(matrices, "https://paceman.gg/stats/api/getSessionStats/?name=meebie&hours=999999&hoursBetween=999999", 10 , 20, 0xfe37f);
         }
 
         if (this.debugHud != null) {
@@ -277,56 +272,6 @@ public class SeedQueueWallScreen extends Screen {
         } catch (IOException e) {
             SeedQueue.LOGGER.warn("File {} failed to be read", path);
         }
-    }
-
-    private void drawCustomTextFromURL(MatrixStack matrices, String urlString, float x, float y, int color) {
-        try {
-            URL url = new URL(urlString);
-            HttpURLConnection connection = (HttpURLConnection) url.openConnection();
-            connection.setRequestMethod("GET");
-            connection.connect();
-            int responseCode = connection.getResponseCode();
-            if (responseCode != 200) {
-                SeedQueue.LOGGER.warn("Bad response: {} from {}", responseCode, urlString);
-            } else {
-                JsonObject jsonObject = getJsonObject(url);
-
-                //Get the required object from the above created object
-                String netherCount = jsonObject.getAsJsonObject("nether").getAsJsonPrimitive("count").getAsString();
-                String netherAverage = jsonObject.getAsJsonObject("nether").getAsJsonPrimitive("avg").getAsString();
-
-                this.textRenderer.draw(matrices, netherCount, x, y, color);
-                this.textRenderer.draw(matrices, netherAverage, x, y+30, color);
-            }
-
-            /* List<StringRenderable> lines = string.stream().map(StringRenderable::plain).collect(Collectors.toList());
-            float height = this.textRenderer.fontHeight;
-            for (StringRenderable line : lines) {
-                this.textRenderer.draw(matrices, line, x, y, color);
-                y += height;
-            }
-            this.textRenderer.draw(matrices, string, x, y, color); */
-        } catch (MalformedURLException e) {
-            SeedQueue.LOGGER.warn("URL {} failed to be read", urlString);
-        } catch (IOException e) {
-            SeedQueue.LOGGER.warn("Browser content at {} failed to be read", urlString);
-        }
-    }
-
-    private static JsonObject getJsonObject(URL url) throws IOException {
-        StringBuilder inline = new StringBuilder();
-        Scanner scanner = new Scanner(url.openStream());
-
-        //Write all the JSON data into a string using a scanner
-        while (scanner.hasNext()) {
-            inline.append(scanner.nextLine());
-        }
-
-        //Close the scanner
-        scanner.close();
-
-        //Using the JSON simple library parse the string into a json object
-        return new JsonParser().parse(inline.toString()).getAsJsonObject();
     }
 
     private boolean playSound(SoundEvent sound) {

--- a/src/main/java/me/contaria/seedqueue/gui/wall/SeedQueueWallScreen.java
+++ b/src/main/java/me/contaria/seedqueue/gui/wall/SeedQueueWallScreen.java
@@ -1,5 +1,6 @@
 package me.contaria.seedqueue.gui.wall;
 
+import com.google.common.io.Files;
 import com.mojang.blaze3d.systems.RenderSystem;
 import me.contaria.seedqueue.SeedQueue;
 import me.contaria.seedqueue.SeedQueueEntry;
@@ -34,7 +35,11 @@ import org.apache.commons.lang3.ArrayUtils;
 import org.jetbrains.annotations.Nullable;
 import org.lwjgl.glfw.GLFW;
 
+import java.io.File;
+import java.nio.charset.Charset;
 import java.util.*;
+import java.nio.file.Path;
+import java.util.stream.IntStream;
 
 public class SeedQueueWallScreen extends Screen {
     private static final Set<WorldRenderer> WORLD_RENDERERS = new HashSet<>();
@@ -165,6 +170,14 @@ public class SeedQueueWallScreen extends Screen {
             this.drawAnimatedTexture(this.overlay, matrices, 0, 0, this.width, this.height);
         }
 
+        if (true) {
+            try {
+                textRenderer.draw(matrices, new LiteralText(Files.readFirstLine(new File("C:\\Users\\Jude\\IdeaProjects\\seedqueue\\run\\config\\mcsr\\atum\\rsg-attempts.txt"), Charset.defaultCharset())), (float) 0, (float) 0, 0xffffff);
+            } catch (Exception e) {
+                SeedQueue.LOGGER.warn("yeah dat shit broke with some error {} idgaf", e);
+            }
+        }
+
         if (this.debugHud != null) {
             SeedQueueProfiler.swap("fps_graph");
             ((DebugHudAccessor) this.debugHud).seedQueue$drawMetricsData(matrices, this.client.getMetricsData(), 0, this.width / 2, true);
@@ -246,6 +259,10 @@ public class SeedQueueWallScreen extends Screen {
                 height * texture.getIndividualFrameCount()
         );
         RenderSystem.disableBlend();
+    }
+
+    private void renderText(Path path) {
+
     }
 
     private boolean playSound(SoundEvent sound) {


### PR DESCRIPTION
specify custom text element(s) in a resource pack using a file path as the source and rendering the text onto the wall in the default minecraft font. 
options for the each custom text element include a pos, color, line spacing (default 9), and shadow (default false)

this can be used to add things like ur reset counter or nph stats file directly onto the wall instead of obs giving a much faster updating rate to things like the atum reset count which counts up much more smoothly here than in obs. also it allows users to actually see the text they add onto their own wall instead of it only being displayed to the stream or recording