### PR TITLE
Adapt mixins to work with chunkbuilder optimized (?) sodium

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,7 +36,7 @@ dependencies {
 	}
 
 	// check for the latest versions at https://jitpack.io/#Minecraft-Java-Edition-Speedrunning/sodium
-	modCompileOnly "com.github.Minecraft-Java-Edition-Speedrunning:sodium:b8785cddfa"
+	modCompileOnly "com.github.Minecraft-Java-Edition-Speedrunning:sodium:d488d3a782"
 
 	// check for the latest versions at https://jitpack.io/#kingcontaria/fastreset
 	modCompileOnly ("com.github.KingContaria:fastreset:82fe8eb3b2") {

--- a/src/main/java/me/contaria/seedqueue/mixin/compat/sodium/ChunkBuilderMixin.java
+++ b/src/main/java/me/contaria/seedqueue/mixin/compat/sodium/ChunkBuilderMixin.java
@@ -34,18 +34,18 @@ public abstract class ChunkBuilderMixin {
     private AtomicBoolean running;
 
     @ModifyReturnValue(
-            method = "getOptimalThreadCount",
+            method = "getMaxThreadCount",
             at = @At("RETURN")
     )
-    private static int modifyChunkUpdateThreads(int optimalThreadCount) {
+    private static int modifyMaxThreads(int maxThreads) {
         if (SeedQueue.isOnWall()) {
             return SeedQueue.config.getChunkUpdateThreads();
         }
-        return optimalThreadCount;
+        return maxThreads;
     }
 
     @ModifyArg(
-            method = "startWorkers",
+            method = "createWorker",
             at = @At(
                     value = "INVOKE",
                     target = "Ljava/lang/Thread;setPriority(I)V"
@@ -85,7 +85,7 @@ public abstract class ChunkBuilderMixin {
     // mac sodium compat is very silly
     @Group(name = "loadCachedBuildBuffersOnWall")
     @WrapOperation(
-            method = "startWorkers",
+            method = "createWorker",
             at = @At(
                     value = "NEW",
                     target = "(Lme/jellysquid/mods/sodium/client/model/vertex/type/ChunkVertexType;Lme/jellysquid/mods/sodium/client/render/chunk/passes/BlockRenderPassManager;)Lme/jellysquid/mods/sodium/client/render/chunk/compile/ChunkBuildBuffers;"
@@ -101,7 +101,7 @@ public abstract class ChunkBuilderMixin {
     @Dynamic
     @Group(name = "loadCachedBuildBuffersOnWall")
     @WrapOperation(
-            method = "startWorkers",
+            method = "createWorker",
             at = @At(
                     value = "NEW",
                     target = "(Lme/jellysquid/mods/sodium/client/gl/attribute/GlVertexFormat;Lme/jellysquid/mods/sodium/client/render/chunk/passes/BlockRenderPassManager;)Lme/jellysquid/mods/sodium/client/render/chunk/compile/ChunkBuildBuffers;"
@@ -115,7 +115,7 @@ public abstract class ChunkBuilderMixin {
     }
 
     @WrapOperation(
-            method = "startWorkers",
+            method = "createWorker",
             at = @At(
                     value = "NEW",
                     target = "(Lnet/minecraft/client/MinecraftClient;Lnet/minecraft/world/World;)Lme/jellysquid/mods/sodium/client/render/pipeline/context/ChunkRenderCacheLocal;",
@@ -132,7 +132,7 @@ public abstract class ChunkBuilderMixin {
 
     @SuppressWarnings("InvalidInjectorMethodSignature") // MCDev doesn't seem to like @Coerce on the return type
     @ModifyExpressionValue(
-            method = "startWorkers",
+            method = "createWorker",
             at = @At(
                     value = "NEW",
                     target = "Lme/jellysquid/mods/sodium/client/render/chunk/compile/ChunkBuilder$WorkerRunnable;"

--- a/src/main/java/me/contaria/seedqueue/mixin/compat/sodium/ChunkBuilderMixin.java
+++ b/src/main/java/me/contaria/seedqueue/mixin/compat/sodium/ChunkBuilderMixin.java
@@ -99,7 +99,7 @@ public abstract class ChunkBuilderMixin {
     }
 
     @Dynamic
-    @Group(name = "loadCachedBuildBuffersOnWall")
+    @Group(name = "loadCachedBuildBuffersOnWall", min = 1, max = 1)
     @WrapOperation(
             method = "createWorker",
             at = @At(

--- a/src/main/java/me/contaria/seedqueue/mixin/compat/sodium/profiling/ChunkBuilderMixin.java
+++ b/src/main/java/me/contaria/seedqueue/mixin/compat/sodium/profiling/ChunkBuilderMixin.java
@@ -27,7 +27,7 @@ public abstract class ChunkBuilderMixin {
     }
 
     @Inject(
-            method = "startWorkers",
+            method = "createWorker",
             at = @At(
                     value = "INVOKE",
                     target = "Lme/jellysquid/mods/sodium/client/render/chunk/compile/ChunkBuildBuffers;<init>(Lme/jellysquid/mods/sodium/client/model/vertex/type/ChunkVertexType;Lme/jellysquid/mods/sodium/client/render/chunk/passes/BlockRenderPassManager;)V"
@@ -38,7 +38,7 @@ public abstract class ChunkBuilderMixin {
     }
 
     @Inject(
-            method = "startWorkers",
+            method = "createWorker",
             at = @At(
                     value = "INVOKE",
                     target = "Lme/jellysquid/mods/sodium/client/render/pipeline/context/ChunkRenderCacheLocal;<init>(Lnet/minecraft/client/MinecraftClient;Lnet/minecraft/world/World;)V",
@@ -50,7 +50,7 @@ public abstract class ChunkBuilderMixin {
     }
 
     @Inject(
-            method = "startWorkers",
+            method = "createWorker",
             at = @At(
                     value = "INVOKE",
                     target = "Lme/jellysquid/mods/sodium/client/render/chunk/compile/ChunkBuilder$WorkerRunnable;<init>(Lme/jellysquid/mods/sodium/client/render/chunk/compile/ChunkBuilder;Lme/jellysquid/mods/sodium/client/render/chunk/compile/ChunkBuildBuffers;Lme/jellysquid/mods/sodium/client/render/pipeline/context/ChunkRenderCacheLocal;)V"
@@ -61,7 +61,7 @@ public abstract class ChunkBuilderMixin {
     }
 
     @Inject(
-            method = "startWorkers",
+            method = "createWorker",
             at = @At(
                     value = "INVOKE",
                     target = "Ljava/lang/Thread;<init>(Ljava/lang/Runnable;Ljava/lang/String;)V"
@@ -72,7 +72,7 @@ public abstract class ChunkBuilderMixin {
     }
 
     @Inject(
-            method = "startWorkers",
+            method = "createWorker",
             at = @At(
                     value = "INVOKE",
                     target = "Ljava/util/List;add(Ljava/lang/Object;)Z"

--- a/src/main/java/me/contaria/seedqueue/mixin/compat/sodium/profiling/ChunkRenderManagerMixin.java
+++ b/src/main/java/me/contaria/seedqueue/mixin/compat/sodium/profiling/ChunkRenderManagerMixin.java
@@ -19,7 +19,7 @@ public abstract class ChunkRenderManagerMixin {
             method = "<init>",
             at = @At(
                     value = "INVOKE",
-                    target = "Lme/jellysquid/mods/sodium/client/render/chunk/compile/ChunkBuilder;<init>(Lme/jellysquid/mods/sodium/client/model/vertex/type/ChunkVertexType;Lme/jellysquid/mods/sodium/client/render/chunk/ChunkRenderBackend;I)V"
+                    target = "Lme/jellysquid/mods/sodium/client/render/chunk/compile/ChunkBuilder;<init>(Lme/jellysquid/mods/sodium/client/model/vertex/type/ChunkVertexType;Lme/jellysquid/mods/sodium/client/render/chunk/ChunkRenderBackend;)V"
             )
     )
     private void profileCreateChunkBuilder(CallbackInfo ci) {

--- a/src/main/java/me/contaria/seedqueue/mixin/compat/sodium/profiling/ChunkRenderManagerMixin.java
+++ b/src/main/java/me/contaria/seedqueue/mixin/compat/sodium/profiling/ChunkRenderManagerMixin.java
@@ -19,7 +19,7 @@ public abstract class ChunkRenderManagerMixin {
             method = "<init>",
             at = @At(
                     value = "INVOKE",
-                    target = "Lme/jellysquid/mods/sodium/client/render/chunk/compile/ChunkBuilder;<init>(Lme/jellysquid/mods/sodium/client/model/vertex/type/ChunkVertexType;Lme/jellysquid/mods/sodium/client/render/chunk/ChunkRenderBackend;)V"
+                    target = "Lme/jellysquid/mods/sodium/client/render/chunk/compile/ChunkBuilder;<init>(Lme/jellysquid/mods/sodium/client/model/vertex/type/ChunkVertexType;Lme/jellysquid/mods/sodium/client/render/chunk/ChunkRenderBackend;I)V"
             )
     )
     private void profileCreateChunkBuilder(CallbackInfo ci) {

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -56,8 +56,8 @@
 		"fast_reset": "<2.0",
 		"state-output": "<1.2",
 		"speedrunigt": "<15.0",
-		"sodium": [ "v1", "v2", "<2.0.1" ],
-		"sodiummac": [ "v2", "v3" ],
+		"sodium": [ "v1", "v2", "<2.4.0" ],
+		"sodiummac": [ "v2", "v3", "<3.4.0" ],
 		"sleepbackground": "<4.0"
 	}
 }


### PR DESCRIPTION
Seems to work based on limited testing. Required for and only works with https://github.com/Minecraft-Java-Edition-Speedrunning/sodium/pull/39/