### PR TITLE
Move stopSeedQueueOnAtumStop to TAIL

### DIFF
--- a/src/main/java/me/contaria/seedqueue/mixin/compat/atum/AtumMixin.java
+++ b/src/main/java/me/contaria/seedqueue/mixin/compat/atum/AtumMixin.java
@@ -56,7 +56,7 @@ public abstract class AtumMixin {
 
     @Inject(
             method = "stopRunning",
-            at = @At("HEAD")
+            at = @At("TAIL")
     )
     private static void stopSeedQueueOnAtumStop(CallbackInfo ci) {
         SeedQueue.stop();


### PR DESCRIPTION
Related to https://github.com/KingContaria/atum-rewrite/pull/12
> In SeedQueue, the stopSeedQueueOnAtumStop mixin needs to be moved to TAIL to allow seeds to be canceled (for futures to be completed immediately and allow exiting)

If the seedqueue thread is currently waiting for a seed future with .join(), which is blocking, and Atum.stopRunning() is called, this mixin with HEAD will wait until that .join() resolves, which can take however long the seed provider wants to take. By moving it to TAIL, Atum.running will be set to false + SEED_FUTURES all cancelled will happen before waiting for the sq thread, which prevents .join() from blocking on the sq thread, even if the sq thread hasn't reached that point in world creation yet (the ordering prevents such a race).

From a quick test, nothing seems to break doing this simple change, and the waiting on .join() issue is solved
I'm not sure if HEAD was an intentional choice originally (cleanup before running = false important?)